### PR TITLE
Add Contributing section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ npx ember-test-helpers-codemod acceptance tests/acceptance
 npx ember-test-helpers-codemod native-dom tests
 ```
 
+Contributing
+------------------------------------------------------------------------------
+
+Contributions are welcome. Please follow the instructions below to install and run the tests.
+
+### Installation
+
+```sh
+yarn install
+```
+
+### Testing
+
+```sh
+yarn test
+```
+
 License
 ------------------------------------------------------------------------------
 ember-mocha-codemods is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Adding a contribution section to README.md to make it easier for others to get started contributing to the codemods.

A section liked this would have helped me get around the initial problems that I mentioned in #114 

I figured since there was little to say about contributing that it could be added straight to the README.md. If this section grows, it may be prudent to move it to a CONTRIBUTING.md file.

