### PR TITLE
Standardizing testing methodology

### DIFF
--- a/__tests__/import-it-from-mocha-test.js
+++ b/__tests__/import-it-from-mocha-test.js
@@ -1,10 +1,40 @@
+/* eslint-env: node */
 'use strict';
 
-const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+const fs = require('fs');
+const path = require('path');
 
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/basic');
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/test-helper');
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/with-comment');
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/with-comment2');
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/with-comment3');
-defineTest(__dirname, 'import-it-from-mocha', {}, 'import-it-from-mocha/with-other-imports');
+const runInlineTest = require('jscodeshift/dist/testUtils').runInlineTest;
+const ImportItFromMochaTransform = require('../import-it-from-mocha');
+const fixtureFolder = `${__dirname}/../__testfixtures__/import-it-from-mocha`;
+
+describe('import-it-from-mocha', function() {
+  fs
+    .readdirSync(fixtureFolder)
+    .filter(filename => /\.input\.js$/.test(filename))
+    .forEach(filename => {
+      let testName = filename.replace('.input.js', '');
+      let inputPath = path.join(fixtureFolder, `${testName}.input.js`);
+      let outputPath = path.join(fixtureFolder, `${testName}.output.js`);
+
+      describe(testName, function() {
+        it('transforms correctly', function() {
+          runInlineTest(
+            ImportItFromMochaTransform,
+            {},
+            { source: fs.readFileSync(inputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+
+        it('is idempotent', function() {
+          runInlineTest(
+            ImportItFromMochaTransform,
+            {},
+            { source: fs.readFileSync(outputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+      });
+    });
+});


### PR DESCRIPTION
There are 3 test runners: 
`fourteen-testing-api-test` (2018),
`import-it-from-mocha-test` (2016),
`new-testing-api-test` (2016).

The two older ones hardcode the names of the tests in the runner itself. This PR updates the two older test runners (`import-it-from-mocha-test`, `new-testing-api-test`) to use the same pattern that `fourteen-testing-api-test` does.

This does 2 things
1.  It removes the need for hardcoded test names in the test runner itself, the tests are just read from their presence in the directory
2. It allows an IDE like Intellj to see the test runner as an actual mocha file, where the tests can be run from the IDE itself
![image](https://user-images.githubusercontent.com/675098/74559751-186dd900-4f33-11ea-9182-3f957ca5389f.png)
